### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   ],
   "entrypoint": "python -m uvicorn main:helpers.app --host 0.0.0.0 --port 8000",
   "description": "Template application to serve custom detection models",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "task_location": "application_sessions",
   "icon_background": "#FFFFFF",
   "icon": "https://user-images.githubusercontent.com/48913536/172667732-552769ce-f93f-41ab-ba76-134d0ca1fb88.png",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   ],
   "entrypoint": "python -m uvicorn main:helpers.app --host 0.0.0.0 --port 8000",
   "description": "Template application to serve custom detection models",
-  "docker_image": "supervisely/base-py-sdk:6.35.0",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "task_location": "application_sessions",
   "icon_background": "#FFFFFF",
   "icon": "https://user-images.githubusercontent.com/48913536/172667732-552769ce-f93f-41ab-ba76-134d0ca1fb88.png",
@@ -15,7 +15,7 @@
   "need_gpu": false,
   "gpu": "preferred",
   "headless": true,
-  "instance_version": "6.4.51",
+  "instance_version": "6.15.60",
   "context_menu": {
     "target": [
       "files_file"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,1 @@
+supervisely==6.73.564

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-supervisely[apps]==6.35.0
+supervisely[apps]==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
